### PR TITLE
NuGet.config copy before docker build

### DIFF
--- a/docs/azure-integration.md
+++ b/docs/azure-integration.md
@@ -12,6 +12,8 @@ Azure Web App supports container, so we will build our application into a Docker
 
 First use the [Dockerfile](../samples/ChatRoom/Dockerfile) to build our application into a Docker container image:
 
+> Make sure you have [NuGet.config](../samples/ChatRoom/NuGet.config) in your project root. 
+
 ```
 docker build -t chatroom .
 ```


### PR DESCRIPTION
There is a need in additional step to add NuGet.config before "docker build" command if user made project step by step via tutorial.