### PR TITLE
typo corrected from broadcase to broadcast

### DIFF
--- a/samples/Serverless/ServerHandler.cs
+++ b/samples/Serverless/ServerHandler.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.SignalR.Samples.Serverless
                               "send users <User Id List>\n" +
                               "send group <Group Name>\n" +
                               "send groups <Group List>\n" +
-                              "broadcase\n" +
+                              "broadcast\n" +
                               "***********************");
         }
     }


### PR DESCRIPTION
typo corrected from broadcase to broadcast in serverless example.