### PR TITLE
Incorrect url generated for sending to single user

### DIFF
--- a/samples/Serverless/ServerHandler.cs
+++ b/samples/Serverless/ServerHandler.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.SignalR.Samples.Serverless
 
         private string GetSendToUserUrl(string hubName, string userId)
         {
-            return $"{GetBaseUrl(hubName)}/user/{userId}";
+            return $"{GetBaseUrl(hubName)}/users/{userId}";
         }
 
         private string GetSendToUsersUrl(string hubName, string userList)


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/azure/azure-signalr/signalr-quickstart-rest-api#sending-to-specific-users

v1 should be '/users' not '/user', v1-preview was to '/user'.