### PR TITLE
handle hub connection closed event

### DIFF
--- a/samples/Management/SignalRClient/Program.cs
+++ b/samples/Management/SignalRClient/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.CommandLineUtils;
@@ -55,6 +56,13 @@ namespace SignalRClient
             {
                 Console.WriteLine($"{userId}: gets message from service: '{message}'");
             });
+
+            connection.Closed += async ex =>
+            {
+                Console.WriteLine(ex);
+                Environment.Exit(1);
+            };
+
             return connection;
         }
     }


### PR DESCRIPTION
handle the hub connection closed event. the closed event will indicate that the error probably caused by external env config, e.g. service mode is incorrect.

some users may set the service mode to default mode, which will result in dropping client connections when the 1st message (including ping messages) reaches the service.