### PR TITLE
upgrade to .Net6.0 for sample QuickStartServerless

### DIFF
--- a/samples/QuickStartServerless/csharp/README.md
+++ b/samples/QuickStartServerless/csharp/README.md
@@ -9,8 +9,10 @@ In this sample, we demonstrate how to broadcast messages with SignalR Service an
 
 ## Setup and run locally
 
-1. Rename `local.settings.template.json` to `local.settings.json` and update `AzureSignalRConnectionString` setting to your SignalR Service connection string.
+1. Rename `local.settings.template.json` to `local.settings.json`, update `AzureSignalRConnectionString` setting to your SignalR Service connection string and `AzureWebJobsStorage` setting to your stroage account connection string.
 
-1. Run `func start` to start Azure Function locally.
+2. In Azure Portal of your SignalR service, update Service Mode from Default to Serverless in Settings Panel.
 
-1. Visit `http://localhost:7071/api/index` and you can see the result.
+3. Run `func start` to start Azure Function locally.
+
+4. Visit `http://localhost:7071/api/index` and you can see the result.

--- a/samples/QuickStartServerless/csharp/csharp.csproj
+++ b/samples/QuickStartServerless/csharp/csharp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
1.  upgrade to .Net 6.0 and still works
2. In `README.md`
2.1  `Service Mode` of SignalR service must be `Serverless` rather than `Normal`
2.2   With the default setting of `AzureWebJobsStorage`, the sample can't work. User should add his own connection string of storage account