### PR TITLE
Update README.md

### DIFF
--- a/samples/ChatRoomLocal/README.md
+++ b/samples/ChatRoomLocal/README.md
@@ -52,7 +52,7 @@ Let's implement this feature step by step.
 
     ```cs
     var builder = WebApplication.CreateBuilder(args);
-    builder.Services.AddSignalR().AddAzureSignalR();
+    builder.Services.AddSignalR();
     var app = builder.Build();
 
     app.UseRouting();


### PR DESCRIPTION
The "AddAzureSignalR()" statement is incorrectly included here. If included, you will get an error: "Microsoft.Azure.SignalR.Common.AzureSignalRConfigurationNoEndpointException: 'No connection string was specified.'"

The AddAzureSignalR() statement should only be added in the next part of the tutorial, when the project is deployed to Azure, and the appropriate package added: Microsoft.Azure.SignalR